### PR TITLE
Schema consistency update

### DIFF
--- a/src/db/addAssessmentItemMgmt.sql
+++ b/src/db/addAssessmentItemMgmt.sql
@@ -1,0 +1,36 @@
+--createFunctions.sql - GradeBook
+
+--Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
+--Created for CS305-71
+--Date of Revision: 10/31/2018
+
+--this script creates the functions used by Team DOS's Gradebook implementation
+
+--check that due date is not before class start date
+--check that due date is not after class end date
+--used in check constraint for AssessmentComponent table
+--takes due date and component id as parameters
+CREATE OR REPLACE FUNCTION DueDateValidityCheck
+(DueDate DATE, ComponentID INT) RETURNS BOOLEAN AS
+$$
+DECLARE
+  SectionEndDate DATE;
+  SectionStartDate DATE;
+BEGIN
+  SectionEndDate = (SELECT EndDate FROM Section
+                    WHERE Section.ID = --getting start date from section related to assessment
+                      (SELECT Section FROM AssessmentComponent
+                        WHERE AssessmentComponent.ID = ComponentID))::date;
+
+  SectionStartDate = (SELECT StartDate FROM Section
+                    WHERE Section.ID = --getting end date from section related to assessment
+                     (SELECT Section FROM AssessmentComponent
+                       WHERE AssessmentComponent.ID = ComponentID))::date;
+
+  IF SectionStartDate <= DueDate AND DueDate <= SectionEndDate THEN
+    RETURN TRUE;
+  ELSE
+    RETURN FALSE;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/db/createTables.sql
+++ b/src/db/createTables.sql
@@ -1,11 +1,12 @@
 --createTables.sql - GradeBook
 
 --Zaid Bhujwala, Zach Boylan, Steven Rollo, Sean Murthy
---Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+--Data Science & Systems Lab (DASSL)
+--Western Connecticut State University (WCSU)
 
 --Edited by Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
 --Edited for CS305-71
---Date of Revision: 10/18/2018
+--Date of Revision: 10/31/2018
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -13,7 +14,8 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
---This script creates schema, tables, and indexes for the Gradebook application
+--This script creates schema, tables, and indexes
+--for the Gradebook application
 
 --E-mail address management is based on the discussion presented at:
 -- https://gist.github.com/smurthys/feba310d8cc89c4e05bdb797ca0c6cac
@@ -24,8 +26,19 @@
 
 --This script assumes a schema named "Gradebook" already exists and is empty
 
+--Spool results to a file in the current directory
+--\o spoolCreateTables.txt
 
-CREATE TABLE Gradebook.Course
+--Echo time, date and user/server/DB info
+--\qecho -n 'Script run on '
+--\qecho -n `date /t`
+--\qecho -n 'at '
+--\qecho `time /t`
+--\qecho -n 'Script run by ' :USER ' on server ' :HOST ' with db ' :DBNAME
+--\qecho ' '
+
+
+CREATE TABLE Course
 (
    --Wonder if this table will eventually need a separate ID field
    Number VARCHAR(8) NOT NULL PRIMARY KEY, --e.g., 'CS170'
@@ -33,10 +46,10 @@ CREATE TABLE Gradebook.Course
 );
 
 
-CREATE TABLE Gradebook.Season
+CREATE TABLE Season
 (
    --Order denotes the sequence of seasons within a year: 0, 1,...9
-   "Order" NUMERIC(1,0) PRIMARY KEY CHECK ("Order" >= 0),
+    Season_Order NUMERIC(1,0) PRIMARY KEY CHECK (Season_Order >= 0),
 
    --Name is a description such as Spring and Summer: must be 2 or more chars
    -- uniqueness is enforced using a case-insensitive index
@@ -48,21 +61,20 @@ CREATE TABLE Gradebook.Season
 );
 
 --enforce case-insensitive uniqueness of season name
-CREATE UNIQUE INDEX idx_Unique_SeasonName ON Gradebook.Season(LOWER(TRIM(Name)));
+CREATE UNIQUE INDEX idx_Unique_SeasonName ON Season(LOWER(TRIM(Name)));
 
-
-CREATE TABLE Gradebook.Term
+CREATE TABLE Term
 (
    ID SERIAL NOT NULL PRIMARY KEY,
    Year NUMERIC(4,0) NOT NULL CHECK (Year > 0), --'2017'
-   Season NUMERIC(1,0) NOT NULL REFERENCES Gradebook.Season,
+   Season NUMERIC(1,0) NOT NULL REFERENCES Season,
    StartDate DATE NOT NULL, --date the term begins
    EndDate DATE NOT NULL, --date the term ends (last day of  "finals" week)
    UNIQUE(Year, Season)
 );
 
 
-CREATE TABLE Gradebook.Instructor
+CREATE TABLE Instructor
 (
    ID SERIAL PRIMARY KEY,
    FName VARCHAR(50) NOT NULL,
@@ -75,19 +87,19 @@ CREATE TABLE Gradebook.Instructor
 
 --enforce case-insensitive uniqueness of instructor e-mail addresses
 CREATE UNIQUE INDEX idx_Unique_InstructorEmail
-ON Gradebook.Instructor(LOWER(TRIM(Email)));
+ON Instructor(LOWER(TRIM(Email)));
 
 --Create a partial index on the instructor names.  This enforces the CONSTRAINT
 -- that only one of any (FName, NULL, LName) is unique
 CREATE UNIQUE INDEX idx_Unique_Names_NULL
-ON Gradebook.Instructor(FName, LName)
+ON Instructor(FName, LName)
 WHERE MName IS NULL;
 
-CREATE TABLE Gradebook.Section
+CREATE TABLE Section
 (
    ID SERIAL PRIMARY KEY,
-   Term INT NOT NULL REFERENCES Gradebook.Term,
-   Course VARCHAR(8) NOT NULL REFERENCES Gradebook.Course,
+   Term INT NOT NULL REFERENCES Term,
+   Course VARCHAR(8) NOT NULL REFERENCES Course,
    SectionNumber VARCHAR(3) NOT NULL, --'01', '72', etc.
    CRN VARCHAR(5) NOT NULL, --store this info for the registrar's benefit?
    Schedule VARCHAR(7),  --days the class meets: 'MW', 'TR', 'MWF', etc.
@@ -95,9 +107,9 @@ CREATE TABLE Gradebook.Section
    StartDate DATE, --first date the section meets
    EndDate DATE, --last date the section meets
    MidtermDate DATE, --date of the "middle" of term: used to compute mid-term grade
-   Instructor1 INT NOT NULL REFERENCES Gradebook.Instructor, --primary instructor
-   Instructor2 INT REFERENCES Gradebook.Instructor, --optional 2nd instructor
-   Instructor3 INT REFERENCES Gradebook.Instructor, --optional 3rd instructor
+   Instructor1 INT NOT NULL REFERENCES Instructor, --primary instructor
+   Instructor2 INT REFERENCES Instructor, --optional 2nd instructor
+   Instructor3 INT REFERENCES Instructor, --optional 3rd instructor
    UNIQUE(Term, Course, SectionNumber),
 
    --make sure instructors are distinct
@@ -108,35 +120,53 @@ CREATE TABLE Gradebook.Section
               )
 );
 
-
 --Table to store all possible letter grades
+--A -> F, standard letter grades
 --some universities permit A+
-CREATE TABLE Gradebook.Grade
+--SA: Stopped attending, W: Withdrawn, TR: Transfer,
+--E: Exlcuded from GPA calculation, AU: Audit
+CREATE TABLE Grade
 (
    Letter VARCHAR(2) NOT NULL PRIMARY KEY,
-   GPA NUMERIC(4,3) NOT NULL,
+   GPA NUMERIC(4,3),
+
+   --Restrict Letter to a list of valid choices
    CONSTRAINT LetterChoices
       CHECK (Letter IN ('A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+',
-                        'C', 'C-', 'D+', 'D', 'D-', 'F', 'W', 'SA')
+                        'C', 'C-', 'D+', 'D', 'D-', 'F', 'SA',
+                        'W', 'TR', 'E', 'AU')
             ),
+
+   --GPA must be of a standard choice, or NULL
    CONSTRAINT GPAChoices
-      CHECK (GPA IN (4.333, 4, 3.667, 3.333, 3, 2.667, 2.333, 2, 1.667, 1.333, 1, 0.667, 0))
+      CHECK (GPA IN (4.333, 4, 3.667, 3.333, 3, 2.667, 2.333, 2, 1.667,
+                    1.333, 1, 0.667, 0)
+              OR GPA IS NULL),
+
+   --Standard letter grades may not have NULL GPA's
+   --Non-standard letter grades may not have GPA's
+   CONSTRAINT LetterChoiceNULLControl
+              CHECK((Letter IN('SA', 'W', 'TR', 'E', 'AU')
+                            AND GPA IS NULL)
+                      OR
+                            (Letter IN('A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+',
+                                       'C', 'C-', 'D+', 'D', 'D-', 'F')
+                             AND GPA IS NOT NULL))
 );
 
 
 --Table to store mapping of percentage score to a letter grade: varies by section
-CREATE TABLE Gradebook.Section_GradeTier
+CREATE TABLE GradeTier
 (
-   Section INT REFERENCES Gradebook.Section,
-   LetterGrade VARCHAR(2) NOT NULL REFERENCES Gradebook.Grade,
-   LowPercentage NUMERIC(4,2) NOT NULL CHECK (LowPercentage > 0),
-   HighPercentage NUMERIC(5,2) NOT NULL CHECK (HighPercentage > 0),
-   PRIMARY KEY(Section, LetterGrade),
-   UNIQUE(Section, LowPercentage, HighPercentage)
+   Section INT REFERENCES Section(ID),
+   LetterGrade VARCHAR(2) NOT NULL REFERENCES Grade(Letter),
+   LowPercentage NUMERIC(4,2) NOT NULL CHECK (LowPercentage >= 0) UNIQUE,
+   HighPercentage NUMERIC(5,2) NOT NULL CHECK (HighPercentage > 0) UNIQUE,
+   PRIMARY KEY(Section, LetterGrade)
 );
 
 
-CREATE TABLE Gradebook.Student
+CREATE TABLE Student
 (
    ID SERIAL PRIMARY KEY,
    FName VARCHAR(50), --at least one of the name fields must be used: see below
@@ -152,13 +182,13 @@ CREATE TABLE Gradebook.Student
 
 --enforce case-insensitive uniqueness of student e-mail addresses
 CREATE UNIQUE INDEX idx_Unique_StudentEmail
-ON Gradebook.Student(LOWER(TRIM(Email)));
+ON Student(LOWER(TRIM(Email)));
 
 
-CREATE TABLE Gradebook.Enrollee
+CREATE TABLE Enrollee
 (
-   Student INT NOT NULL REFERENCES Gradebook.Student,
-   Section INT REFERENCES Gradebook.Section,
+   Student INT NOT NULL REFERENCES Student,
+   Section INT REFERENCES Section,
    DateEnrolled DATE NULL, --used to figure out which assessment components to include/exclude
    YearEnrolled VARCHAR(30) NOT NULL,
    MajorEnrolled VARCHAR(50) NOT NULL,
@@ -169,67 +199,77 @@ CREATE TABLE Gradebook.Enrollee
    FinalGradeComputed VARCHAR(2),  --will eventually move to a view
    FinalGradeAwarded VARCHAR(2), --actual grade assigned
    PRIMARY KEY (Student, Section),
-   FOREIGN KEY (Section, MidtermGradeAwarded) REFERENCES Gradebook.Section_GradeTier,
-   FOREIGN KEY (Section, FinalGradeAwarded) REFERENCES Gradebook.Section_GradeTier
+   FOREIGN KEY (Section, MidtermGradeAwarded) REFERENCES GradeTier,
+   FOREIGN KEY (Section, FinalGradeAwarded) REFERENCES GradeTier
 );
 
 
-CREATE TABLE Gradebook.AttendanceStatus
+CREATE TABLE AttendanceStatus
 (
    Status CHAR(1) NOT NULL PRIMARY KEY, --'P', 'A', ...
    Description VARCHAR(20) NOT NULL UNIQUE --'Present', 'Absent', ...
 );
 
 
-CREATE TABLE Gradebook.AttendanceRecord
+CREATE TABLE AttendanceRecord
 (
    Student INT NOT NULL,
    Section INT NOT NULL,
    Date DATE NOT NULL,
-   Status CHAR(1) NOT NULL REFERENCES Gradebook.AttendanceStatus,
+   Status CHAR(1) NOT NULL REFERENCES AttendanceStatus,
    PRIMARY KEY (Student, Section, Date),
-   FOREIGN KEY (Student, Section) REFERENCES Gradebook.Enrollee
+   FOREIGN KEY (Student, Section) REFERENCES Enrollee
 );
 
 
-CREATE TABLE Gradebook.Section_AssessmentComponent
+CREATE TABLE AssessmentComponent
 (
-   Section INT NOT NULL REFERENCES Gradebook.Section,
-   ID INT NOT NULL,
-   Type VARCHAR(20) NOT NULL UNIQUE, --"Assignment", "Quiz", "Exam",...
-   Weight NUMERIC(3,2) NOT NULL CHECK (Weight >= 0), --a percentage value: 0.25, 0.5,...
+   ID INT NOT NULL PRIMARY KEY,
+   Section INT NOT NULL REFERENCES Section(ID),
+   Type VARCHAR NOT NULL, --"Assignment", "Quiz", "Exam",...
+   Weight NUMERIC(5,2) NOT NULL
+        --allowing weight 0 allows graded assignments with no weight
+        --e.g. graded feedback on practice
+        --weight can also not be > 100
+        CHECK ((Weight >= 0) AND (Weight <= 100)),
    Description VARCHAR NULL,
-   NumItems INT NOT NULL DEFAULT 1,
-   PRIMARY KEY (Section, ID)
+   NumItems INT NOT NULL DEFAULT 1
 );
 
-
-CREATE TABLE Gradebook.Section_AssessmentItem
+--Table mapping assessment items to parent component items
+CREATE TABLE AssessmentItem
 (
-   Section INT NOT NULL,
-   Component_ID VARCHAR(20) NOT NULL,
-   SequenceInComponent INT NOT NULL  NOT NULL CHECK (SequenceInComponent > 0),
-   BasePoints NUMERIC(5,2) NOT NULL CHECK (BasePoints >= 0),
-   ExtraCreditPoints NUMERIC(5,2) NOT NULL DEFAULT 0 CHECK (ExtraCreditPoints >= 0),
-   AssignedDate Date,
-   DueDate Date,
-   Curve NUMERIC(5,2) NULL CHECK(Curve > 0),
-   PRIMARY KEY(Section, Component_ID, SequenceInComponent),
-   FOREIGN KEY (Section, Component_ID) REFERENCES Gradebook.Section_AssessmentComponent
+  Component INT NOT NULL REFERENCES AssessmentComponent(ID),
+  SequenceInComponent INT NOT NULL NOT NULL CHECK (SequenceInComponent > 0),
+  BasePoints NUMERIC(10,2) NOT NULL CHECK (BasePoints > 0), --Item cannot be worth 0 points
+  ExtraCreditPoints NUMERIC(10,2) NOT NULL DEFAULT 0 CHECK (ExtraCreditPoints >= 0),
+  AssignedDate Date,
+  DueDate Date CHECK (DueDate >= AssignedDate), --item can not be due before it's assigned
+  Curve NUMERIC(5,2) NULL CHECK(Curve > 0),
+
+  CONSTRAINT DateVailidty --confirm that section startdate <= item duedate <= section enddate
+          CHECK(DueDateValidityCheck(DueDate, Component)),
+
+  PRIMARY KEY(Component, SequenceInComponent)
 );
 
-
-CREATE TABLE Gradebook.Enrollee_AssessmentItem
+--table mapping enrollee submissions of asssessment items
+CREATE TABLE Submission
 (
    Student INT NOT NULL,
    Section INT NOT NULL,
-   Component VARCHAR(20) NOT NULL,
+   Component INT NOT NULL,
    SequenceInComponent INT NOT NULL,
-   BasePointsEarned NUMERIC(5,2) CHECK (BasePointsEarned >= 0),
-   ExtraCreditPointsEarned NUMERIC(5,2) CHECK (ExtraCreditPointsEarned >= 0),
+   BasePointsEarned NUMERIC(5,2) CHECK (BasePointsEarned >= 0), --points earned cannot be negative
+   ExtraCreditPointsEarned NUMERIC(5,2) CHECK (ExtraCreditPointsEarned >= 0), --extra credit cannot be negative
    SubmissionDate DATE,
-   Penalty NUMERIC(5,2) CHECK (Penalty >= 0),
+   Penalty NUMERIC(5,2) CHECK (Penalty >= 0), --penalty cannot be negative
+   InstructorNote VARCHAR,
    PRIMARY KEY(Student, Section, Component, SequenceInComponent),
-   FOREIGN KEY (Student, Section) REFERENCES Gradebook.Enrollee,
-   FOREIGN KEY (Section, Component, SequenceInComponent) REFERENCES Gradebook.Section_AssessmentItem
+   FOREIGN KEY (Student, Section) REFERENCES Enrollee,
+   FOREIGN KEY (Component, SequenceInComponent) REFERENCES AssessmentItem
 );
+
+
+--turn spooling off
+--\o

--- a/src/db/dropTables.sql
+++ b/src/db/dropTables.sql
@@ -1,7 +1,12 @@
---createTables.sql - GradeBook
+--dropTables.sql - GradeBook
 
 --Zaid Bhujwala, Zach Boylan, Steven Rollo, Sean Murthy
 --Data Science & Systems Lab (DASSL), Western Connecticut State University (WCSU)
+
+--Edited by Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
+--Edited for CS305-71
+--Date of Revision: 10/31/2018
+
 
 --(C) 2017- DASSL. ALL RIGHTS RESERVED.
 --Licensed to others under CC 4.0 BY-SA-NC
@@ -9,32 +14,36 @@
 
 --PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
---remove the following two comment lines after discussion
---use camel case for table/field names containing more than one word
---use hyphen in table names when combining multiple table names as in that for a m-n relationship
+--This script drops all tables created by createTables.sql, if they exist, with CASCADE
 
 START TRANSACTION;
 
-
---Remove the following line to drop tables from default schema instead
-SET LOCAL SCHEMA 'gradebook';
-
-
 DROP TABLE IF EXISTS Course CASCADE;
-DROP TABLE IF EXISTS Season CASCADE;
-DROP TABLE IF EXISTS Term CASCADE;
-DROP TABLE IF EXISTS Instructor CASCADE;
-DROP TABLE IF EXISTS Section CASCADE;
-DROP TABLE IF EXISTS Grade CASCADE;
-DROP TABLE IF EXISTS Section_GradeTier CASCADE;
-DROP TABLE IF EXISTS Student CASCADE;
-DROP TABLE IF EXISTS Enrollee CASCADE;
-DROP TABLE IF EXISTS AttendanceStatus CASCADE;
-DROP TABLE IF EXISTS AttendanceRecord CASCADE;
-DROP TABLE IF EXISTS Section_AssessmentComponent CASCADE;
-DROP TABLE IF EXISTS Section_AssessmentItem CASCADE;
-DROP TABLE IF EXISTS Enrollee_AssessmentItem CASCADE;
-DROP TABLE IF EXISTS openCloseStaging CASCADE;
 
+DROP TABLE IF EXISTS Season CASCADE;
+
+DROP TABLE IF EXISTS Term CASCADE;
+
+DROP TABLE IF EXISTS Instructor CASCADE;
+
+DROP TABLE IF EXISTS Section CASCADE;
+
+DROP TABLE IF EXISTS Grade CASCADE;
+
+DROP TABLE IF EXISTS GradeTier CASCADE;
+
+DROP TABLE IF EXISTS Student CASCADE;
+
+DROP TABLE IF EXISTS Enrollee CASCADE;
+
+DROP TABLE IF EXISTS AttendanceStatus CASCADE;
+
+DROP TABLE IF EXISTS AttendanceRecord CASCADE;
+
+DROP TABLE IF EXISTS AssessmentComponent CASCADE;
+
+DROP TABLE IF EXISTS AssessmentItem CASCADE;
+
+DROP TABLE IF EXISTS Submission CASCADE;
 
 COMMIT;


### PR DESCRIPTION
`addAssessmentItemMgmt.sql` contains the function definition for a function that is used to validate `AssessmentItem.DueDate`. It ensures that `Section.StartDate` <= `DueDate` <= `Section.EndDate`, for the section related to each assessment item. In future, a similar constraint can be placed on `AssessmentItem.AssignedDate` (ensuring no item is assigned after a section ends).

`createTable.sql` has been updated to implements the above check constraint. The table definitions for all tables have been made consistent with the Optimized logical schema. This included renaming certain attributes for clarity, and adding attributes. 

The most significant changes were to the `Grade` and `GradeTier` tables. New options for letter grades have been added, and a constraint has been put in place to control what grades can have `NULL` values.

The schema quantifying has been removed from all table definitions as per Dr. Murthy's recommendation. This will allow us to experiment with the script files in our own instances of classDB, where we don't have access to a schema named gradebook.

`dropTable.sql` has been updated with the revised table names, and the `SET SCHEMA` statement has been removed.
