### PR TITLE
Create assessment management

### DIFF
--- a/src/db/addAssessmentComponentMgmt.sql
+++ b/src/db/addAssessmentComponentMgmt.sql
@@ -1,0 +1,109 @@
+--addAssessmentComponentMgmt.sql - GradeBook
+
+--Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
+--Created for CS305-71
+--Date of Revision: 11/7/2018
+
+--this script creates the functions used by Team DOS's Gradebook
+--implements management features for AssessmentComponents
+--This includes: reading, deleting, updating
+
+
+--Deletes the AssessmentComponent with an ID == the input value
+--First, mus delete all tables with the ComponentToDelete as a foreign key
+--begins by deleting all Sumbissions with a foreign key to the ComponentToDelete
+--then deleting all AssessmentItems that refference the ComponentToDelete
+--then deleting the AssessmentComponent instance with an ID == ComponentToDelete
+CREATE OR REPLACE FUNCTION RemoveAssessmentComponent(ComponentToDelete INT)
+RETURNS BOOLEAN AS
+$$
+BEGIN
+
+  --delete submissions first
+  --submission have a foreign key to AssessmentComponent and AssessmentItem
+  DELETE FROM Submission WHERE Component = $1;
+
+  --now we can delete from AssessmentItem
+  --AssessmentItem has a foreign key to AssessmentComponent
+  DELETE FROM AssessmentItem WHERE Component = $1;
+
+  --now delete from AssessmentComponent
+  DELETE FROM AssessmentComponent WHERE ID = $1;
+
+  --returns true if successful
+  RETURN TRUE;
+
+END;
+$$ LANGUAGE plpgsql
+   VOLATILE
+   RETURNS NULL ON NULL INPUT
+   SECURITY INVOKER;
+
+
+--This functions returns all assessment components
+CREATE OR REPLACE FUNCTION getAssessmentComponents()
+RETURNS TABLE
+(
+  ID INT,
+  Section INT,
+  Type VARCHAR,
+  Weight NUMERIC(5,2),
+  Description VARCHAR,
+  NumItems INT
+)
+AS
+$$
+
+      SELECT  ID, Section, Type, Weight, Description, NumItems
+      FROM AssessmentComponent;
+
+$$ LANGUAGE sql
+    STABLE
+    ROWS 1;
+
+
+--This functions returns a 1 row table containing an AssessmentComponent
+--When given a single parameter, which is a ComponentID
+CREATE OR REPLACE FUNCTION getAssessmentComponent(ComponentID INT)
+RETURNS TABLE
+(
+  Section INT,
+  Type VARCHAR,
+  Weight NUMERIC(5,2),
+  Description VARCHAR,
+  NumItems INT
+)
+AS
+$$
+
+      SELECT  Section, Type, Weight, Description, NumItems
+      FROM AssessmentComponent
+      WHERE ID = $1;
+
+$$ LANGUAGE sql
+    STABLE
+    RETURNS NULL ON NULL INPUT
+    ROWS 1;
+
+
+--This functions returns a table containing each AssessmentComponent
+--with a Section == the given parameter
+CREATE OR REPLACE FUNCTION getAssessmentComponentWithSection(SectionID INT)
+RETURNS TABLE
+(
+  ID INT,
+  Type VARCHAR,
+  Weight NUMERIC(5,2),
+  Description VARCHAR,
+  NumItems INT
+)
+AS
+$$
+
+      SELECT  ID, Type, Weight, Description, NumItems
+      FROM AssessmentComponent
+      WHERE Section = $1;
+
+$$ LANGUAGE sql
+    STABLE
+    RETURNS NULL ON NULL INPUT;

--- a/src/db/addAssessmentItemMgmt.sql
+++ b/src/db/addAssessmentItemMgmt.sql
@@ -1,10 +1,12 @@
---createFunctions.sql - GradeBook
+--assAssessmentItemMgmt.sql - GradeBook
 
 --Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
 --Created for CS305-71
---Date of Revision: 10/31/2018
+--Date of Revision: 11/8/2018
 
---this script creates the functions used by Team DOS's Gradebook implementation
+--this script creates the functions used by Team DOS's Gradebook
+--implements management features for AssessmentItems
+--This includes: reading, deleting, updating
 
 --check that due date is not before class start date
 --check that due date is not after class end date
@@ -33,4 +35,104 @@ BEGIN
     RETURN FALSE;
   END IF;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql
+    VOLATILE
+    RETURNS NULL ON NULL INPUT
+    SECURITY INVOKER;
+
+
+--this function is used to fully remove an AssessmentItem and it's dependents
+--begins by deleting all sumbissions that refference the AssessmentItem to delete
+--then deleting the AssessmentItem indicated by the input parameter
+CREATE OR REPLACE FUNCTION RemoveAssessmentItem(ItemToDelete INT)
+RETURNS BOOLEAN AS
+$$
+BEGIN
+
+  --delete submissions first
+  --submission have a foreign key to AssessmentComponent and AssessmentItem
+  DELETE FROM Submission WHERE Component = $1;
+
+  --now we can delete from AssessmentItem
+  --AssessmentItem has a foreign key to AssessmentComponent
+  DELETE FROM AssessmentItem WHERE Component = $1;
+
+  --returns true if successful
+  RETURN TRUE;
+
+END;
+$$ LANGUAGE plpgsql
+   VOLATILE
+   RETURNS NULL ON NULL INPUT
+   SECURITY INVOKER;
+
+--This functions returns all rows of AssessmentItem
+CREATE OR REPLACE FUNCTION getAssessmentItems()
+RETURNS TABLE
+(
+  Component INT,
+  SequenceInComponent INT,
+  BasePoints NUMERIC(6,2),
+  ExtraCreditPoints NUMERIC(6,2),
+  AssignedDate DATE,
+  DueDate DATE,
+  Curve NUMERIC(5,2)
+)
+AS
+$$
+
+      SELECT  Component, SequenceInComponent, BasePoints, ExtraCreditPoints,
+      AssignedDate, DueDate, Curve
+      FROM AssessmentItem;
+
+$$ LANGUAGE sql
+    STABLE
+    ROWS 1;
+
+--This functions returns a table containing 1 row of an AssessmentItem
+--where the row has the given Component and SequenceInComponent
+CREATE OR REPLACE FUNCTION getAssessmentItemsWithComponent
+                              (ComponentID INT, SequenceInComponent INT)
+RETURNS TABLE
+(
+  BasePoints NUMERIC(6,2),
+  ExtraCreditPoints NUMERIC(6,2),
+  AssignedDate DATE,
+  DueDate DATE,
+  Curve NUMERIC(5,2)
+)
+AS
+$$
+
+      SELECT BasePoints, ExtraCreditPoints,
+      AssignedDate, DueDate, Curve
+      FROM AssessmentItem
+      WHERE Component = $1 AND SequenceInComponent = $2;
+
+$$ LANGUAGE sql
+    STABLE
+    RETURNS NULL ON NULL INPUT;
+
+--This functions returns a table containing 0 or more rows of AssessmentItems
+--where each row shares a Component
+CREATE OR REPLACE FUNCTION getAssessmentItemsWithComponent(ComponentID INTEGER)
+RETURNS TABLE
+(
+  SequenceInComponent INT,
+  BasePoints NUMERIC(6,2),
+  ExtraCreditPoints NUMERIC(6,2),
+  AssignedDate DATE,
+  DueDate DATE,
+  Curve NUMERIC(5,2)
+)
+AS
+$$
+
+      SELECT SequenceInComponent, BasePoints, ExtraCreditPoints,
+      AssignedDate, DueDate, Curve
+      FROM AssessmentItem
+      WHERE Component = $1;
+
+$$ LANGUAGE sql
+    STABLE
+    RETURNS NULL ON NULL INPUT;

--- a/src/db/addSubmissionMgmt.sql
+++ b/src/db/addSubmissionMgmt.sql
@@ -1,0 +1,34 @@
+--addSubmissionMgmt.sql - GradeBook
+
+--Team DOS: Kyle Bella, Kenneth Kozlowski, Joe Tether
+--Created for CS305-71
+--Date of Revision: 11/8/2018
+
+--this script creates the functions used by Team DOS's Gradebook
+--implements management features for Submissions
+--This includes: reading, deleting, updating
+
+
+
+CREATE OR REPLACE FUNCTION CreateSubmission(Student INT, Section INT,
+                                            Component INT, SequenceInComponent INT
+                                            BasePointsEarned NUMERIC,
+                                            ExtraCreditPointsEarned NUMERIC
+                                            SubmissionDate DATE, Penalty NUMERIC,
+                                            InstructorNote VARCHAR)
+RETURNS BOOLEAN AS
+$$
+BEGIN
+
+  INSERT INTO Submission
+  VALUES(Student, Section, Component, SequenceInComponent BasePointsEarned,
+        ExtraCreditPointsEarned, SubmissionDate, Penalty, InstructorNote);
+
+  --returns true if successful
+  RETURN TRUE;
+
+END;
+$$ LANGUAGE plpgsql
+   VOLATILE
+   RETURNS NULL ON NULL INPUT
+   SECURITY INVOKER;


### PR DESCRIPTION
Created files `addAssessmentComponentMgmt.sql`, `addSubmissionMgmt.sql`, and edited 'addAssessmentItemMgtm.sql'. Each of these files now contain function definitions for various read, delete, and edit queries to be used when interacting with the DBMS from an outside source. I modeled the functions based on the requirements in FR12.1 and 12.2. 

Each script has been run successfully on a personal instance of postgres, alongside the other scripts from our project. So far some basic testing with the sample data has confirmed they work as intended.