### PR TITLE
Add new before login ui

### DIFF
--- a/src/webapp/client/html/README.md
+++ b/src/webapp/client/html/README.md
@@ -1,0 +1,50 @@
+#README.md
+<!--This is the README document for the pre-login part of the User Interface. This document will explain all of the pages that are implemented in this part of the program and will explain the functionality used in the program. -->
+Kyle Bella, Kenneth Kozlowski and Joseph Tether  
+CS305-71  
+Team DOS
+***  
+
+Date of Last Revision: *November 5, 2018*  
+Modified by: *Kenneth Kozlowski*
+
+<!--This document was created using MacDown, a free program for writing markdown files on MAC OSX-->
+
+***
+
+###General Information
+
+Most of the CSS Styling in this part of the program is from https://materializecss.com/   
+  
+All of the pages present before a login attempt is completed will show the user a screen with `Gradebook - Sample Institution` at the top left corner of the page. The user will then see navigation at the top right hand of the page where there are three tabs shown `Login`, `About` and `Change Log`.  
+
+The navigation tabs will load the page that corresponds to the Tabs title.  
+
+Clicking on the `Login` tab will bring the user to `login.html`  
+Clicking on the `About` tab will bring the user to `about.html`
+Clicking on the `Change Log` tab will bring the user to `changeLog.html`
+
+*NOTE*: `Sample Institution` can be changed in all of the files to reflect the name of the institution that is using the product.  
+To change the name of the institution, all of the HTML files would need to be opened in a text editor and the line: `      			<a href="#" class="brand-logo"> Gradebook - Sample Institution</a>
+` can be changed to say `Gradebook - Institution Name`.
+
+***
+
+###Login.html
+The user will be prompted by the program to enter in their login credentials.  
+The login credentials that will be accepted by the program will be a valid email address and a password. After that the program will determine if the username of the email address is a valid database user and if they are the password will be authenticated so the user could login or not.
+
+***
+###About.html
+This page contains all of the About information that was included in the DASSL Implementation of Gradebook.  
+There is only one line that was added on this page and that line was to mention the names of all of the members of Team DOS to give them credit for the modifications that were made to the program for the DOS Implementation of Gradebook.
+
+***
+###ChangeLog.html
+This page will show a list of all of the changes made to Gradebook from the DASSL Implementation of the program to the DOS implementation of the program.  
+As of now, the list is just maintained as one large numbered list.
+<!--Now refers to Current Date of 10/31/2018-->
+
+<!-- This will probably need to be changed in the future because the list will probably be reorganized with different categories for all of the changes to fall under.-->
+
+

--- a/src/webapp/client/html/README.md
+++ b/src/webapp/client/html/README.md
@@ -1,4 +1,4 @@
-#README.md
+# README.md
 <!--This is the README document for the pre-login part of the User Interface. This document will explain all of the pages that are implemented in this part of the program and will explain the functionality used in the program. -->
 Kyle Bella, Kenneth Kozlowski and Joseph Tether  
 CS305-71  
@@ -12,7 +12,7 @@ Modified by: *Kenneth Kozlowski*
 
 ***
 
-###General Information
+### General Information  
 
 Most of the CSS Styling in this part of the program is from https://materializecss.com/   
   
@@ -21,7 +21,7 @@ All of the pages present before a login attempt is completed will show the user 
 The navigation tabs will load the page that corresponds to the Tabs title.  
 
 Clicking on the `Login` tab will bring the user to `login.html`  
-Clicking on the `About` tab will bring the user to `about.html`
+Clicking on the `About` tab will bring the user to `about.html`  
 Clicking on the `Change Log` tab will bring the user to `changeLog.html`
 
 *NOTE*: `Sample Institution` can be changed in all of the files to reflect the name of the institution that is using the product.  
@@ -30,17 +30,17 @@ To change the name of the institution, all of the HTML files would need to be op
 
 ***
 
-###Login.html
+### Login.html  
 The user will be prompted by the program to enter in their login credentials.  
 The login credentials that will be accepted by the program will be a valid email address and a password. After that the program will determine if the username of the email address is a valid database user and if they are the password will be authenticated so the user could login or not.
 
 ***
-###About.html
+### About.html  
 This page contains all of the About information that was included in the DASSL Implementation of Gradebook.  
 There is only one line that was added on this page and that line was to mention the names of all of the members of Team DOS to give them credit for the modifications that were made to the program for the DOS Implementation of Gradebook.
 
 ***
-###ChangeLog.html
+### ChangeLog.html  
 This page will show a list of all of the changes made to Gradebook from the DASSL Implementation of the program to the DOS implementation of the program.  
 As of now, the list is just maintained as one large numbered list.
 <!--Now refers to Current Date of 10/31/2018-->

--- a/src/webapp/client/html/about.html
+++ b/src/webapp/client/html/about.html
@@ -25,7 +25,7 @@ Date of Last Revision: October 30, 2018
 		<title>About | Gradebook</title>
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<!--Import Materialize framework - Learn more: http://materializecss.com/-->
-	<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+	<link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
 	</head>
 	<body>
 		 <nav>

--- a/src/webapp/client/html/about.html
+++ b/src/webapp/client/html/about.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<!--
+about.html - Gradebook (DOS Implementation)
+
+This is the About page for the Gradebook application. All of the information on this page with the acception of  the note about the revision of the application and its requirements is taken from the original Gradebook application.
+
+The page will have 3 tabs at the top of the page:
+	1. A tab that will bring you to the login page.
+	2. A tab that will keep you on the About page.
+	3. A Change Log page that will describe the changes made from the existing implementation of Gradebook to the DOS implementation.
+
+
+NOTES:
+* The institution name can be changed as needed for the institution that will be using this product
+
+
+Team Members: Kyle Bella, Kenneth Kozlowski, Joseph Tether
+CS 305-71
+TEAM DOS
+
+Author: Kenneth Kozlowski
+Date of Last Revision: October 30, 2018
+-->
+	<head>
+		<title>About | Gradebook</title>
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<!--Import Materialize framework - Learn more: http://materializecss.com/-->
+	<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+	</head>
+	<body>
+		 <nav>
+    		<div class="nav-wrapper">
+      			<a href="#" class="brand-logo"> Gradebook - Sample Institution</a>
+     			<ul id="nav-mobile" class="right hide-on-med-and-down">
+        			<li><a href="login.html">Login</a></li>
+        			<li><a href="about.html">About</a></li>
+        			<li><a href="changeLog.html">Change Log</a></li>
+      			</ul>
+    	    </div>
+    	</nav><!--End of header navigation-->
+    	
+    	
+    	
+    	<div class="container">
+		    <div class="section">
+		        <h2>About Gradebook</h2>
+		        <p>Gradebook is an open-source product for instructors to record student
+		 assessment and attendance. It is developed at the Data Science &amp;
+		 Systems Lab (<a href="https://dassl.github.io" target="_blank">DASSL</a>
+		 , read <em>dazzle</em>) at the Western Connecticut State University 
+		 (<a href="http://wcsu.edu/" target="_blank">WCSU</a>).</p>
+		 <p>This implementation has been revised by Members of Team DOS: Kyle Bella, Kenneth Kozlowski and Joseph Tether for a term project in CS305-71 at WCSU.</p>
+		        <h5>Goals</h5>
+		        <p>Gradebook is developed with the following goals:</p>
+		        <ol>
+			        <li>Provide instructors a free, open, and modern tool to record 
+			 student assessment and attendance</li>
+			        <li>Provide instructors a framework to surface, analyze, and visualize
+			 patterns in student performance</li>
+			        <li>Use (and demonstrate the use of) modern tools and processes in
+			 software and data engineering</li>
+			        <li>Provide Computer Science students a real-life application to
+			 develop and maintain as both curricular and co-curricular activity</li>
+			        <li>Provide Computer Science students a framework to experience
+			 first-hand topics such as: web and mobile application development;
+			 RESTful APIs; multi-tenancy; scalability; and cloud-based services.</li>
+		        </ol>
+		        <h5>Status</h5>
+		        <p>Gradebook is still in early stages of development (“alpha stage”).
+		 Much of its external documentation is in the form of README files
+		 contained in various directories within the product repository. The
+		 source code is commented reasonably well. More information about Gradebook
+		 can be found by visiting its
+		        <a href="https://github.com/DASSL/Gradebook" target="_blank"> repository
+		 on GitHub</a>.</p>
+		        <p><strong>Caution:</strong> Because the product is still in very early
+		 stages of development, it should not be used as a production system in
+		 its current state. There are no guarantees that future development
+		 releases will provide any kind of backward compatibility or portability.</p>
+		        <h5>Contributors</h5>
+		        <p>Gradebook was conceived by and is designed by 
+		 <a href="http://sites.wcsu.edu/murthys/" target="_blank">Sean Murthy</a>,
+		 a member of the Computer Science faculty at WCSU.</p>
+		        <p>The following undergraduate Computer Science students at WCSU
+		 contribute(d) to the development of Gradebook:</p>
+		        <ul class="browser-default">
+			        <li><a href="https://github.com/bella004" target="_blank">Kyle Bella</a></li>
+			        <li><a href="https://github.com/zbhujwala" target="_blank">Zaid Bhujwala</a></li>
+			        <li><a href="https://github.com/ZBoylan" target="_blank">Zach Boylan</a></li>
+			        <li><a href="https://github.com/afig" target="_blank">Andrew Figueroa</a></li>
+			        <li><a href="https://github.com/griffine" target="_blank">Elly Griffin</a></li>
+			        <li><a href="https://github.com/srrollo" target="_blank">Steven Rollo</a></li>
+			        <li><a href="https://github.com/hunterSchloss" target="_blank">Hunter Schloss</a></li>
+		        </ul>
+		        <h5>Legal Stuff</h5>
+			    <p>© 2017- DASSL. ALL RIGHTS RESERVED.</p>
+			    <p>Gradebook is distributed under
+			<a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">
+			 Creative Commons License BY-NC-SA 4.0</a>.</p>
+			    <p>PROVIDED AS IS. NO WARRANTIES EXPRESSED OR IMPLIED. USE AT YOUR OWN
+			 RISK.</p>
+		    </div><!--End section div-->
+		</div><!--End Container div-->
+		
+	</body> <!--End of document-->

--- a/src/webapp/client/html/changeLog.html
+++ b/src/webapp/client/html/changeLog.html
@@ -18,13 +18,13 @@ CS 305-71
 TEAM DOS
 
 Author: Kenneth Kozlowski
-Date of Last Revision: October 30, 2018
+Date of Last Revision: November 5, 2018
 -->
 	<head>
 		<title>Change Log | Gradebook</title>
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<!--Import Materialize framework - Learn more: http://materializecss.com/-->
-	<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+	<link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
 	</head>
 	<body>
 		 <nav>

--- a/src/webapp/client/html/changeLog.html
+++ b/src/webapp/client/html/changeLog.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+changeLog.html - Gradebook (DOS Implementation)
+
+This is the page that will show all of the changes that have been made from the original Gradebook Implementation to the DOS implementation of Gradebook
+
+The page will have 3 tabs at the top of the page:
+	1. A tab that will bring you to the login page.
+	2. A tab that will keep you on the About page.
+	3. A Change Log page that will describe the changes made from the existing implementation of Gradebook to the DOS implementation.
+
+
+NOTES:
+* The institution name can be changed as needed for the institution that will be using this product
+
+Team Members: Kyle Bella, Kenneth Kozlowski, Joseph Tether
+CS 305-71
+TEAM DOS
+
+Author: Kenneth Kozlowski
+Date of Last Revision: October 30, 2018
+-->
+	<head>
+		<title>Change Log | Gradebook</title>
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+	<!--Import Materialize framework - Learn more: http://materializecss.com/-->
+	<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+	</head>
+	<body>
+		 <nav>
+    		<div class="nav-wrapper">
+      			<a href="#" class="brand-logo"> Gradebook - Sample Institution</a>
+     			<ul id="nav-mobile" class="right hide-on-med-and-down">
+        			<li><a href="login.html">Login</a></li>
+        			<li><a href="about.html">About</a></li>
+        			<li><a href="changeLog.html">Change Log</a></li>
+      			</ul>
+    	    </div>
+    	</nav><!--End of header navigation-->
+    	
+    	
+    	<div class="container">
+		    <div class="section">
+    	        <h4 class="center-align"><u>Change Log From DASSL Gradebook Implementation to DOS Gradebook Implementation</u></h4>
+    	        <br>
+    	            <!--This list may be changed in the future to break down the changes into different categories.-->
+    	            <ol>
+    	                <li><p>The login interface was changed from being part of the main screen on Gradebook to now being its own page that will show before the main screen will show when program is running.</p></li>
+    	                <li><p>A change was made to the About page where there is a small comment stating who the authors of the DOS revision of Gradebook are.</p></li>
+    	                <li><p>The Navigation pane at the top of the page has been changed where the tabs are all listed at the top right of the page.</p></li>
+    	                <li><p>A sample institution name was added on the title of the product that can be changed by any institution that uses this program.</p></li>
+    	                <li><p>This Change Log Page was created to show the differences between the implementations.</p></li>
+    	        
+    	        </ol><!--End of the list of changes made-->
+    	    </div> <!--End section div-->
+    	</div> <!--End Container Div-->
+	</body><!--End of document-->

--- a/src/webapp/client/html/login.html
+++ b/src/webapp/client/html/login.html
@@ -7,7 +7,7 @@ This page will have the imput boxes to accept a username and password from the e
 
 The page will have 3 tabs at the top of the page:
 	1. A tab that will keep you on the current log in page.
-	2. The About tab that will contain the information that the existing Gradebook About 			  tab contains 
+	2. The About tab that will contain the information that the existing Gradebook About tab contains 
 	3. A changes page that will describe the changes made from the existing implementation of Gradebook to the DOS implementation
 
 NOTES: 
@@ -24,12 +24,11 @@ CS 305-71
 TEAM DOS
 
 Author: Kenneth Kozlowski
-Date of Last Revision: November 1, 2018
+Date of Last Revision: November 5, 2018
 -->
 	<html>
 		<head>
 			<title>Login | Gradebook</title>
-			<!--  TODO: Add in the stylesheet link here!  -->
 			<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 		<!--Import Materialize framework - Learn more: http://materializecss.com/-->
 		<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
@@ -75,6 +74,7 @@ Date of Last Revision: November 1, 2018
 						</div>
 					<a id="btnLogin" class="waves-effect waves-light btn">Login</a>
 					</div><!--End Login div-->
+					
 					<br><hr><br>
 					<div>
 						<p> <strong><u>NOTICE</u></strong>: This system is only accessible to users that have been allowed access. Any unauthorized use of this system will result in prosecution.
@@ -91,11 +91,7 @@ Date of Last Revision: November 1, 2018
 							<div class="modal-footer">
 								<a href="#!" class="modal-action modal-close waves-effect waves-gray btn-flat">OK</a>
 								
-								<!--
-								This functionality is not working yet. 
-								There is an error in the index.js file where the DB connection info is not communicating correctly. 
-								We are investigating at this time.
-								-->
+
 								
 							</div>
 						</div>

--- a/src/webapp/client/html/login.html
+++ b/src/webapp/client/html/login.html
@@ -31,7 +31,7 @@ Date of Last Revision: November 5, 2018
 			<title>Login | Gradebook</title>
 			<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 		<!--Import Materialize framework - Learn more: http://materializecss.com/-->
-		<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+		<link type="text/css" rel="stylesheet" href="../css/materialize.min.css"  media="screen,projection"/>
 		</head>
 		<body>
 			 <nav>

--- a/src/webapp/client/html/login.html
+++ b/src/webapp/client/html/login.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<!--
+login.html - Gradebook (DOS Implementation)
+
+This is the implementation of the Gradebook Desktop application Log in Page.
+This page will have the imput boxes to accept a username and password from the end user and then check with the server to verify that the username and password provided were correct. Then the application will load the main page of Gradebook.
+
+The page will have 3 tabs at the top of the page:
+	1. A tab that will keep you on the current log in page.
+	2. The About tab that will contain the information that the existing Gradebook About 			  tab contains 
+	3. A changes page that will describe the changes made from the existing implementation of Gradebook to the DOS implementation
+
+NOTES: 
+* The main page of Gradebook used in this implementation will be the default page from the published Gradebook version.
+
+* The institution name can be changed as needed for the institution that will be using this product
+
+*There is an issue when trying to process the login with the file index.js - errors are being returned and further research is needed to resolve the issue.
+    *There is an issue created on Github for the bug in index.js
+    *All of these HTML files will be uploaded to Github once the issue is resolved.
+
+Team Members: Kyle Bella, Kenneth Kozlowski, Joseph Tether
+CS 305-71
+TEAM DOS
+
+Author: Kenneth Kozlowski
+Date of Last Revision: November 1, 2018
+-->
+	<html>
+		<head>
+			<title>Login | Gradebook</title>
+			<!--  TODO: Add in the stylesheet link here!  -->
+			<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<!--Import Materialize framework - Learn more: http://materializecss.com/-->
+		<link type="text/css" rel="stylesheet" href="css/materialize.min.css"  media="screen,projection"/>
+		</head>
+		<body>
+			 <nav>
+				<div class="nav-wrapper">
+					<a href="#" class="brand-logo"> Gradebook - Sample Institution</a>
+				
+					<!--This list will be the pre-login navigation bar. These will change once the user is logged into the system.-->
+					<ul id="nav-mobile" class="right hide-on-med-and-down">
+						<li><a href="login.html">Login</a></li>
+						<li><a href="about.html">About</a></li>
+						<li><a href="changeLog.html">Change Log</a></li>
+					</ul>
+			
+				</div>
+			</nav>
+	
+	
+			<div class="container"> <!--Adds left and right spacing for content-->
+				<div class="section"> <!--Adds spacing between navbar and content-->
+	
+					<div id="login" class="center-align">		
+						<div class="row">
+							<h5>Login</h5>
+						</div>
+						<div class="row">
+							<div class="input-field col s12">
+								<i class="material-icons prefix">mail</i>
+								<input id="email" type="email"/>
+								<label for="email">Email</label>
+							</div>
+						</div>
+						<div class="row">
+							<div class="center-align">
+								<div class="input-field col s12">
+									<i class="material-icons prefix">lock</i>
+									<input id="passwordBox" type="password"/>
+									<label for="passwordBox">Password</label>
+								</div>
+							</div>
+						</div>
+					<a id="btnLogin" class="waves-effect waves-light btn">Login</a>
+					</div><!--End Login div-->
+					<br><hr><br>
+					<div>
+						<p> <strong><u>NOTICE</u></strong>: This system is only accessible to users that have been allowed access. Any unauthorized use of this system will result in prosecution.
+					<br><br>
+					If you are having difficulty logging into the system please contact the system administrator.
+					<br><br>
+					<strong><u>Other Note</u></strong>: This can be changed for each institution.
+						</p>
+					</div><!--End of paragraph div-->
+				
+					<!--Generic alert used by showAlert() in index.js-->
+					<div id="msg-genericAlert" class="modal">
+						<div id="genericAlertBody" class="modal-content"></div>
+							<div class="modal-footer">
+								<a href="#!" class="modal-action modal-close waves-effect waves-gray btn-flat">OK</a>
+								
+								<!--
+								This functionality is not working yet. 
+								There is an error in the index.js file where the DB connection info is not communicating correctly. 
+								We are investigating at this time.
+								-->
+								
+							</div>
+						</div>
+					</div><!--End alert box div-->
+				
+				</div><!--End section div-->
+			</div><!--End container div-->
+		</body>
+	
+	
+	
+		<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+		<script type="text/javascript" src="../js/materialize.min.js"></script>
+		<script type="text/javascript" src="../js/index.js"></script>
+		<script src="https://bitwiseshiftleft.github.io/sjcl/sjcl.js"></script>
+	</html>

--- a/src/webapp/client/js/index.js
+++ b/src/webapp/client/js/index.js
@@ -4,6 +4,13 @@ index.js - Gradebook
 Andrew Figueroa
 Data Science & Systems Lab (DASSL), Western Connecticut State University
 
+
+Modified by team DOS (Kyle Bella, Kenneth Kozlowski and Joseph Tether)
+CS 305-71 @ WCSU
+Last To Make Modification: Kenneth Kozlowski
+Date of Last Revision: 11/2/2018
+
+
 Copyright (c) 2017- DASSL. ALL RIGHTS RESERVED.
 Licensed to others under CC 4.0 BY-NC-SA
 https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -22,7 +29,7 @@ Currently, a globally scoped variable is used to store login information.
  client cookies.
 */
 var dbInfo = {
-	"host":null, "port":null, "database":null, "user":null, "password":null,
+	"host":'localhost', "port":5432, "database":'gradebook', "user":null, "password":null,
 	 "instructorid":null
 };
 var instInfo = { "fname":null, "mname":null, "lname": null, "dept":null };
@@ -60,7 +67,25 @@ $(document).ready(function() {
 	$('#btnLogin').click(function() {
 		dbInfo = getDBFields();
 		var email = $('#email').val().trim();
-		if (dbInfo != null && email != '') {
+		
+		
+		/*This outer if/else checks to verify the domain name of the email address to verify that the user is logging 
+		in with the correct email address. This will also help to prevent unauthorized users to log into the system 
+		if the case would arrive where someone would use an email address like 'something@gmail.com' to spoof the 
+		username of 'something@sample.edu' for example to gain access into the system.
+		
+		The 'sample.edu' domain name and the 'connect.sample.edu' domain name can be changed to match any domain name 
+		that the end uer needs to make  sure will work.
+		
+		The connect.sample.edu domain name is there to verify that when a student logs into the application that their 
+		email address will be verified as correct. A different check is done in the if to make sure that a student 
+		can log in as well as instructors. This is here to make sure that institutions that use different email 
+		domains for students and faculty is covered.
+		*/
+		if(email.endsWith('@sample.edu') || email.endsWith('@connect.sample.edu'))
+		{
+		    if (dbInfo != null && email != '') 
+		    {
 			serverLogin(dbInfo, email, function() {
 				//clear login fields and close DB Info box
 				$('#email').val('');
@@ -70,11 +95,17 @@ $(document).ready(function() {
 				
 				popYears(dbInfo);
 			});
+		    }
+		    else 
+		    {
+			showAlert('<h5><u>ERROR</u></h5><p>The username or password field is not filled in.' +
+				  'Please make sure all fields are filled in</p>');
+		    }
 		}
-		else {
-			showAlert('<h5>Missing field(s)</h5><p>One or more fields are ' +
-			 'not filled in.</p><p>All fields are required, including those in ' +
-			 'DB Info.</p>');
+		else
+		{
+		showAlert('<h5><u>Login Incomplete</u></h5><p>The domain name of the email address provided is not recognized' +
+			  'by the server.<br> Please try again or contact support if you believe this is an error.</p>');
 		}
 	});
 	


### PR DESCRIPTION
These are all of the files for the M5 requirements which add 3 pages to the UI:

- `login.html`
- `about.html`
- `changeLog.html`

`login.html` shows a basic login screen that will take an email and password and take the information submitted and send it to the server to be processed.

`about.html` shows the same about information as the DASSL about page showed.

`changeLog.html` shows a running list of changes made from the original DASSL implementation of Gradebook to our Version of Gradebook.


A README file was created to provide a clear high level summary of each of the pages in the `html` folder.

Some changes were made to `index.js` to add in the hardcoded infomration for the location and some of the details about where the DB is.

